### PR TITLE
Fixing a bug in _pagination_links

### DIFF
--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -145,7 +145,7 @@ defmodule Scrivener.HTML do
     content_tag :nav do
       content_tag :ul, class: "pagination" do
         raw_pagination_links(paginator, params)
-        |> Enum.map fn ({text, page_number})->
+        |> Enum.map(fn ({text, page_number})->
           classes = []
           if paginator.page_number == page_number do
             classes = ["active"]
@@ -160,7 +160,7 @@ defmodule Scrivener.HTML do
               content_tag :a, "#{text}", class: class
             end
           end
-        end
+        end)
       end
     end
   end
@@ -169,7 +169,7 @@ defmodule Scrivener.HTML do
   defp _pagination_links(paginator, [view_style: :semantic, path: path, args: args, params: params]) do
     content_tag :div, class: "ui pagination menu" do
       raw_pagination_links(paginator, params)
-      |> Enum.map fn({text, page_number}) ->
+      |> Enum.map(fn({text, page_number}) ->
         classes = ["item"]
         if paginator.page_number == page_number do
           classes = ["active", "item"]
@@ -182,7 +182,7 @@ defmodule Scrivener.HTML do
         else
           content_tag :a, "#{text}", class: class
         end
-      end
+      end)
     end
   end
 

--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -144,7 +144,7 @@ defmodule Scrivener.HTML do
   defp _pagination_links(paginator, [view_style: :bootstrap, path: path, args: args, params: params]) do
     content_tag :nav do
       content_tag :ul, class: "pagination" do
-        raw_pagination_links(paginator)
+        raw_pagination_links(paginator, params)
         |> Enum.map fn ({text, page_number})->
           classes = []
           if paginator.page_number == page_number do
@@ -168,7 +168,7 @@ defmodule Scrivener.HTML do
   # Semantic UI implementation
   defp _pagination_links(paginator, [view_style: :semantic, path: path, args: args, params: params]) do
     content_tag :div, class: "ui pagination menu" do
-      raw_pagination_links(paginator)
+      raw_pagination_links(paginator, params)
       |> Enum.map fn({text, page_number}) ->
         classes = ["item"]
         if paginator.page_number == page_number do

--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -142,6 +142,7 @@ defmodule Scrivener.HTML do
 
   # Bootstrap implementation
   defp _pagination_links(paginator, [view_style: :bootstrap, path: path, args: args, params: params]) do
+    url_params = Dict.drop params, Dict.keys(@raw_defaults)
     content_tag :nav do
       content_tag :ul, class: "pagination" do
         raw_pagination_links(paginator, params)
@@ -150,7 +151,7 @@ defmodule Scrivener.HTML do
           if paginator.page_number == page_number do
             classes = ["active"]
           end
-          params_with_page = Dict.merge(params, page: page_number)
+          params_with_page = Dict.merge(url_params, page: page_number)
           content_tag :li do
             to = apply(path, args ++ [params_with_page])
             class = Enum.join(classes, " ")
@@ -167,6 +168,7 @@ defmodule Scrivener.HTML do
 
   # Semantic UI implementation
   defp _pagination_links(paginator, [view_style: :semantic, path: path, args: args, params: params]) do
+    url_params = Dict.drop params, Dict.keys(@raw_defaults)
     content_tag :div, class: "ui pagination menu" do
       raw_pagination_links(paginator, params)
       |> Enum.map(fn({text, page_number}) ->
@@ -174,7 +176,7 @@ defmodule Scrivener.HTML do
         if paginator.page_number == page_number do
           classes = ["active", "item"]
         end
-        params_with_page = Dict.merge(params, page: page_number)
+        params_with_page = Dict.merge(url_params, page: page_number)
         to = apply(path, args ++ [params_with_page])
         class = Enum.join(classes, " ")
         if to do


### PR DESCRIPTION
The `params` list didn't get forwarded to `raw_pagination_links` and thus the `next`, `previous`, ... options didn't work.

Second commit fixes a warnig with newer Elixir versions