### PR TITLE
FIX: Bootstrap active class is set on the li, not the a element

### DIFF
--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -152,13 +152,12 @@ defmodule Scrivener.HTML do
             classes = ["active"]
           end
           params_with_page = Dict.merge(url_params, page: page_number)
-          content_tag :li do
+          content_tag :li, class: Enum.join(classes, " ") do
             to = apply(path, args ++ [params_with_page])
-            class = Enum.join(classes, " ")
             if to do
-              link "#{text}", to: apply(path, args ++ [params_with_page]), class: class
+              link "#{text}", to: apply(path, args ++ [params_with_page])
             else
-              content_tag :a, "#{text}", class: class
+              content_tag :a, "#{text}"
             end
           end
         end)

--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -155,7 +155,7 @@ defmodule Scrivener.HTML do
           content_tag :li, class: Enum.join(classes, " ") do
             to = apply(path, args ++ [params_with_page])
             if to do
-              link "#{text}", to: to)
+              link "#{text}", to: to
             else
               content_tag :a, "#{text}"
             end

--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -155,7 +155,7 @@ defmodule Scrivener.HTML do
           content_tag :li, class: Enum.join(classes, " ") do
             to = apply(path, args ++ [params_with_page])
             if to do
-              link "#{text}", to: apply(path, args ++ [params_with_page])
+              link "#{text}", to: to)
             else
               content_tag :a, "#{text}"
             end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ScrivenerHtml.Mixfile do
 
   def project do
     [app: :scrivener_html,
-     version: "1.0.6",
+     version: "1.0.7",
      elixir: "~> 1.0",
      name: "scrivener_html",
      source_url: "git@github.com:mgwidmann/scrivener_html.git",

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ScrivenerHtml.Mixfile do
 
   def project do
     [app: :scrivener_html,
-     version: "1.0.7",
+     version: "1.0.6",
      elixir: "~> 1.0",
      name: "scrivener_html",
      source_url: "git@github.com:mgwidmann/scrivener_html.git",

--- a/test/scrivener/html_test.exs
+++ b/test/scrivener/html_test.exs
@@ -175,7 +175,7 @@ defmodule Scrivener.HTMLTest do
 
       assert {:safe, ["<nav>",
                       ["<ul class=\"pagination\">",
-                        [["<li>", ["<a class=\"active\">", "1", "</a>"], "</li>"]],
+                        [["<li class=\"active\">", ["<a>", "1", "</a>"], "</li>"]],
                       "</ul>"],
                     "</nav>"]} =
         HTML.pagination_links(conn(), %Page{entries: [], page_number: 1, page_size: 10, total_entries: 0, total_pages: 0})


### PR DESCRIPTION
Small fix that correctly generates bootstrap pagination html