### PR TITLE
Implemented Foundation for Sites 6.x style

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,21 @@ Where `@page` is a `%Scrivener.Page{}` struct returned from `Repo.paginate/2`.
 Customize output. Below are the defaults.
 
 ```elixir
-<%= pagination_links @conn, @page, distance: 5, next: ">>", previous: "<<", first: true, last: true %>
+<%= pagination_links @conn, @page, distance: 5, next: ">>", previous: "<<", first: true, last: true, view_style: :bootstrap %>
 ```
 
-See `Scrivener.HTML.raw_pagination_links/2` for option descriptions.
+There are three view styles currently supported:
+
+- `:bootstrap` (the default) This styles the pagination links in a manner that
+  is expected by Bootstrap 3.x.
+- `:foundation` This styles the pagination links in a manner that is expected
+  by Foundation for Sites 6.x.
+- `:semantic` This styles the pagination links in a manner that is expected by
+  Semantic UI 2.x.
 
 For custom HTML output, see `Scrivener.HTML.raw_pagination_links/2`.
+
+See `Scrivener.HTML.raw_pagination_links/2` for option descriptions.
 
 Scrivener.HTML can be included in your view and then just used with a simple call to `pagination_links/1`.
 

--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -1,7 +1,7 @@
 defmodule Scrivener.HTML do
   use Phoenix.HTML
   @defaults [view_style: :bootstrap, action: :index]
-  @view_styles [:bootstrap, :semantic]
+  @view_styles [:bootstrap, :semantic, :foundation]
   @raw_defaults [distance: 5, next: ">>", previous: "<<", first: true, last: true]
   @moduledoc """
   For use with Phoenix.HTML, configure the `:routes_helper` module like the following:
@@ -182,6 +182,34 @@ defmodule Scrivener.HTML do
           link "#{text}", to: apply(path, args ++ [params_with_page]), class: class
         else
           content_tag :a, "#{text}", class: class
+        end
+      end)
+    end
+  end
+
+  # Foundation for Sites 6.x implementation
+  defp _pagination_links(paginator, [view_style: :foundation, path: path, args: args, params: params]) do
+    url_params = Dict.drop params, Dict.keys(@raw_defaults)
+    content_tag :ul, class: "pagination", role: "pagination" do
+      raw_pagination_links(paginator, params)
+      |> Enum.map(fn({text, page_number}) ->
+        classes = []
+        if paginator.page_number == page_number do
+          classes = ["current"]
+        end
+        params_with_page = Dict.merge(url_params, page: page_number)
+        to = apply(path, args ++ [params_with_page])
+        class = Enum.join(classes, " ")
+        content_tag :li, class: class do
+          if paginator.page_number == page_number do
+            content_tag :span, "#{text}"
+          else
+            if to do
+              link "#{text}", to: apply(path, args ++ [params_with_page])
+            else
+              content_tag :a, "#{text}"
+            end
+          end
         end
       end)
     end

--- a/test/scrivener/html_test.exs
+++ b/test/scrivener/html_test.exs
@@ -144,7 +144,7 @@ defmodule Scrivener.HTMLTest do
       end
 
       it "uses application config" do
-        assert_raise RuntimeError, "Scrivener.HTML: View style :another_style is not a valid view style. Please use one of [:bootstrap, :semantic]", fn ->
+        assert_raise RuntimeError, "Scrivener.HTML: View style :another_style is not a valid view style. Please use one of [:bootstrap, :semantic, :foundation]", fn ->
           HTML.pagination_links(%Page{total_pages: 10, page_number: 5})
         end
       end
@@ -193,6 +193,20 @@ defmodule Scrivener.HTMLTest do
                         [["<a class=\"active item\">", "1", "</a>"]],
                       "</div>"]} =
           HTML.pagination_links(conn(), %Page{entries: [], page_number: 1, page_size: 10, total_entries: 0, total_pages: 0})
+      end
+    end
+
+    describe "Foundation for Sites 6.x" do
+      it "renders Foundation for Sites 6.x styling" do
+        use Phoenix.ConnTest
+        Application.put_env(:scrivener_html, :view_style, :foundation)
+        Application.put_env(:scrivener_html, :routes_helper, MyApp.Router.Helpers)
+
+        assert {:safe, ["<ul class=\"pagination\" role=\"pagination\">",
+                        [["<li class=\"current\">", ["<span>", "1", "</span>"], "</li>"],
+                         ["<li class=\"\">", ["<a>", "2", "</a>"], "</li>"],
+                         ["<li class=\"\">", ["<a>", "&gt;&gt;", "</a>"], "</li>"]], "</ul>"]} =
+          HTML.pagination_links(conn(), %Page{entries: [], page_number: 1, page_size: 10, total_entries: 20, total_pages: 2})
       end
     end
   end


### PR DESCRIPTION
Hello,

I implemented the Foundation for Sites 6.x styling (though I think it'd work for Foundation 5.x as well). I updated an affected test and added another test for Foundation styling.

Since this now makes three visual styles, I could update the README to note the different styles it now supports.

Let me know if you need anything else.

Thanks