### PR TITLE
Fix previous positioning

### DIFF
--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -237,8 +237,8 @@ defmodule Scrivener.HTML do
   def raw_pagination_links(paginator, options \\ []) do
     options = Keyword.merge @raw_defaults, options
 
-    add_previous(paginator.page_number)
-    |> add_first(paginator.page_number, options[:distance], options[:first])
+    add_first(paginator.page_number, options[:distance], options[:first])
+    |> add_previous(paginator.page_number)
     |> page_number_list(paginator.page_number, paginator.total_pages, options[:distance])
     |> add_last(paginator.page_number, paginator.total_pages, options[:distance], options[:last])
     |> add_next(paginator.page_number, paginator.total_pages)
@@ -277,18 +277,18 @@ defmodule Scrivener.HTML do
   end
 
   # Adding next/prev/first/last links
-  defp add_previous(page) when page != 1 do
-    [:previous]
+  defp add_previous(list, page) when page != 1 do
+    [:previous | list]
   end
-  defp add_previous(_page) do
-    []
+  defp add_previous(list, _page) do
+    list
   end
 
-  defp add_first(list, page, distance, true) when page - distance > 1 do
-    [1 | list]
+  defp add_first(page, distance, true) when page - distance > 1 do
+    [1]
   end
-  defp add_first(list, _page, _distance, _included) do
-    list
+  defp add_first(_page, _distance, _included) do
+    []
   end
 
   defp add_last(list, page, total, distance, true) when page + distance < total do

--- a/test/scrivener/html_test.exs
+++ b/test/scrivener/html_test.exs
@@ -68,6 +68,10 @@ defmodule Scrivener.HTMLTest do
         assert pages_with_previous(49, 45..55) == links_with_opts [total_pages: 100, page_number: 50], previous: "<<"
       end
 
+      it "includes a previous before the first" do
+        assert [{"<<", 49}] ++ [{1, 1}] ++ pages(45..55) == links_with_opts [total_pages: 100, page_number: 50], previous: "<<", first: true
+      end
+
       it "does not include previous when equal to page 1" do
         assert pages(1..6) == links_with_opts [total_pages: 10, page_number: 1], previous: "<<"
       end


### PR DESCRIPTION
More coherent to always put the previous sign in the front, also when first page is enabled. This is in line with the behaviour of last and next.