### PR TITLE
Relax version requirement to support Phoenix 1.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ScrivenerHtml.Mixfile do
   def project do
     [app: :scrivener_html,
      version: "1.0.10",
-     elixir: "~> 1.0",
+     elixir: "~> 1.2",
      name: "scrivener_html",
      source_url: "git@github.com:mgwidmann/scrivener_html.git",
      homepage_url: "https://github.com/mgwidmann/scrivener_html",

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule ScrivenerHtml.Mixfile do
     [
       {:scrivener, "~> 1.0"},
       {:phoenix_html, "~> 2.2"},
-      {:phoenix, "~> 1.0", optional: true},
+      {:phoenix, "~> 1.0 or ~> 1.2-rc", optional: true},
       {:pavlov, github: "sproutapp/pavlov", only: :test},
       {:ex_doc, "~> 0.10", only: :dev},
       {:earmark, "~> 0.1", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -4,9 +4,10 @@
   "ex_doc": {:hex, :ex_doc, "0.10.0"},
   "meck": {:hex, :meck, "0.8.4"},
   "pavlov": {:git, "https://github.com/sproutapp/pavlov.git", "7f3c0d7c75c8c2875e21b495511a291194bfc85a", []},
-  "phoenix": {:hex, :phoenix, "1.1.0"},
+  "phoenix": {:hex, :phoenix, "1.2.0-rc.0"},
   "phoenix_html": {:hex, :phoenix_html, "2.3.0"},
-  "plug": {:hex, :plug, "1.0.3"},
-  "poison": {:hex, :poison, "1.5.0"},
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.0-rc.0"},
+  "plug": {:hex, :plug, "1.1.4"},
+  "poison": {:hex, :poison, "1.5.2"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "scrivener": {:hex, :scrivener, "1.0.0"}}

--- a/test/scrivener/html_test.exs
+++ b/test/scrivener/html_test.exs
@@ -187,7 +187,7 @@ defmodule Scrivener.HTMLTest do
                         [["<li class=\"active\">", ["<a>", "1", "</a>"], "</li>"]],
                       "</ul>"],
                     "</nav>"]} =
-        HTML.pagination_links(conn(), %Page{entries: [], page_number: 1, page_size: 10, total_entries: 0, total_pages: 0})
+        HTML.pagination_links(build_conn(), %Page{entries: [], page_number: 1, page_size: 10, total_entries: 0, total_pages: 0})
     end
   end
 
@@ -201,7 +201,7 @@ defmodule Scrivener.HTMLTest do
         assert {:safe, ["<div class=\"ui pagination menu\">",
                         [["<a class=\"active item\">", "1", "</a>"]],
                       "</div>"]} =
-          HTML.pagination_links(conn(), %Page{entries: [], page_number: 1, page_size: 10, total_entries: 0, total_pages: 0})
+          HTML.pagination_links(build_conn(), %Page{entries: [], page_number: 1, page_size: 10, total_entries: 0, total_pages: 0})
       end
     end
 
@@ -215,7 +215,7 @@ defmodule Scrivener.HTMLTest do
                         [["<li class=\"current\">", ["<span>", "1", "</span>"], "</li>"],
                          ["<li class=\"\">", ["<a>", "2", "</a>"], "</li>"],
                          ["<li class=\"\">", ["<a>", "&gt;&gt;", "</a>"], "</li>"]], "</ul>"]} =
-          HTML.pagination_links(conn(), %Page{entries: [], page_number: 1, page_size: 10, total_entries: 20, total_pages: 2})
+          HTML.pagination_links(build_conn(), %Page{entries: [], page_number: 1, page_size: 10, total_entries: 20, total_pages: 2})
       end
     end
   end


### PR DESCRIPTION
Also removed usage of the deprecated test helper `conn/0` in favor of `build_conn/0`.