### PR TITLE
Fix ellipsis rendering (logic + formatting)

### DIFF
--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -174,13 +174,13 @@ defmodule Scrivener.HTML do
     page({:ellipsis, unquote(@raw_defaults[:ellipsis])}, url_params, args, page_param, path, paginator, style)
   end
   defp page({:ellipsis, text}, _url_params, args, _page_param, _path, paginator, :semantic) do
-    content_tag(:div, to_string(text), class: link_classes_for_style(paginator, :ellipsis, :semantic) |> Enum.join(" "))
+    content_tag(:div, {:safe, to_string(text)}, class: link_classes_for_style(paginator, :ellipsis, :semantic) |> Enum.join(" "))
   end
   defp page({:ellipsis, text}, _url_params, args, _page_param, _path, paginator, style) do
     content_tag(:li, class: li_classes_for_style(paginator, :ellipsis, style) |> Enum.join(" ")) do
       style
       |> ellipsis_tag
-      |> content_tag(to_string(text), class: link_classes_for_style(paginator, :ellipsis, style) |> Enum.join(" "))
+      |> content_tag({:safe, to_string(text)}, class: link_classes_for_style(paginator, :ellipsis, style) |> Enum.join(" "))
     end
   end
 

--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -323,14 +323,14 @@ defmodule Scrivener.HTML do
     list
   end
 
-  defp add_first_ellipsis(list, page, total, distance) when page + distance < total and page > 1 do
+  defp add_first_ellipsis(list, page, total, distance) when page - distance > 1 and page > 1 do
     list ++ [:first_ellipsis]
   end
   defp add_first_ellipsis(list, _page_number, _total, _distance) do
     list
   end
 
-  defp add_last_ellipsis(list, page, total, distance) when page - distance > 1 and page != total do
+  defp add_last_ellipsis(list, page, total, distance) when page + distance < total and page != total do
     list ++ [:last_ellipsis]
   end
   defp add_last_ellipsis(list, _page_number, _total, _distance) do

--- a/test/scrivener/html_test.exs
+++ b/test/scrivener/html_test.exs
@@ -142,8 +142,18 @@ defmodule Scrivener.HTMLTest do
         assert pages(1..6) == links_with_opts [total_pages: 8, page_number: 1], first: true, ellipsis: "&hellip;"
       end
 
+      it "uses ellipsis only beyond <distance> of first page" do
+        assert pages(1..11) == links_with_opts [total_pages: 20, page_number: 6], first: true, ellipsis: "&hellip;"
+        assert [{1, 1}, {:ellipsis, "&hellip;"}] ++ pages(2..12) == links_with_opts [total_pages: 20, page_number: 7], first: true, ellipsis: "&hellip;"
+      end
+
       it "does not include ellipsis on last page" do
         assert pages(15..20) == links_with_opts [total_pages: 20, page_number: 20], last: true, ellipsis: "&hellip;"
+      end
+
+      it "uses ellipsis only beyond <distance> of last page" do
+        assert pages(10..20) == links_with_opts [total_pages: 20, page_number: 15], last: true, ellipsis: "&hellip;"
+        assert pages(9..19) ++ [{:ellipsis, "&hellip;"}, {20, 20}] == links_with_opts [total_pages: 20, page_number: 14], last: true, ellipsis: "&hellip;"
       end
 
     end

--- a/test/scrivener/html_test.exs
+++ b/test/scrivener/html_test.exs
@@ -254,12 +254,19 @@ defmodule Scrivener.HTMLTest do
         Application.put_env(:scrivener_html, :routes_helper, MyApp.Router.Helpers)
 
         assert {:safe, ["<ul class=\"pagination\" role=\"pagination\">",
-                        [["<li class=\"\">", ["<a>", "&lt;&lt;", "</a>"], "</li>"], ["<li class=\"\">", ["<a>", "1", "</a>"], "</li>"], ["<li class=\"\">", ["<a>", "2", "</a>"], "</li>"],
-                         ["<li class=\"current\">", ["<span>", "3", "</span>"], "</li>"], ["<li class=\"\">", ["<a>", "4", "</a>"], "</li>"], ["<li class=\"\">", ["<a>", "5", "</a>"], "</li>"],
-                         ["<li class=\"\">", ["<a>", "6", "</a>"], "</li>"], ["<li class=\"\">", ["<a>", "7", "</a>"], "</li>"], ["<li class=\"\">", ["<a>", "8", "</a>"], "</li>"],
-                         ["<li class=\"ellipsis\">", "", "</li>"], ["<li class=\"\">", ["<a>", "10", "</a>"], "</li>"], ["<li class=\"\">", ["<a>", "&gt;&gt;", "</a>"], "</li>"]], "</ul>"]}
-
-          HTML.pagination_links(build_conn(), %Page{entries: [], page_number: 3, page_size: 10, total_entries: 100, total_pages: 10}, [] , ellipsis: true)
+                        [["<li class=\"\">", ["<span class=\"\">", "&lt;&lt;", "</span>"], "</li>"],
+                         ["<li class=\"\">", ["<span class=\"\">", "1", "</span>"], "</li>"],
+                         ["<li class=\"\">", ["<span class=\"\">", "2", "</span>"], "</li>"],
+                         ["<li class=\"current\">", ["<span class=\"\">", "3", "</span>"], "</li>"],
+                         ["<li class=\"\">", ["<span class=\"\">", "4", "</span>"], "</li>"],
+                         ["<li class=\"\">", ["<span class=\"\">", "5", "</span>"], "</li>"],
+                         ["<li class=\"\">", ["<span class=\"\">", "6", "</span>"], "</li>"],
+                         ["<li class=\"\">", ["<span class=\"\">", "7", "</span>"], "</li>"],
+                         ["<li class=\"\">", ["<span class=\"\">", "8", "</span>"], "</li>"],
+                         ["<li class=\"ellipsis\">", ["<span class=\"\">", "&hellip;", "</span>"], "</li>"],
+                         ["<li class=\"\">", ["<span class=\"\">", "10", "</span>"], "</li>"],
+                         ["<li class=\"\">", ["<span class=\"\">", "&gt;&gt;", "</span>"], "</li>"]], "</ul>"]} ==
+          HTML.pagination_links(build_conn(), %Page{entries: [], page_number: 3, page_size: 10, total_entries: 100, total_pages: 10}, [], ellipsis: true)
       end
     end
   end


### PR DESCRIPTION
The ellipsis placement logic was reversed (more or less), and it also tried to render `&hellip;` directly in a `content_tag`, causing it to be escaped into `&amp;hellip;`.

This pull request fixes both issues, at least as far as I can tell by the added / modified tests and the Phoenix app I'm using Scrivener.HTML in.

_**NOTE:** I enabled the "Foundation for Sites 6.x" ellipsis test (which was missing `==` after the expected output), and modified it to match the actual HTML that's output by `HTML.pagination_links`.. except for the incorrectly rendered ellipsis, of course._