### PR TITLE
optionally run with Scrivener 2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule ScrivenerHtml.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:scrivener, "~> 1.2"},
+      {:scrivener, "~> 1.2 or ~> 2.0.0"},
       {:phoenix_html, "~> 2.2"},
       {:phoenix, "~> 1.0 or ~> 1.2", optional: true},
       {:pavlov, github: "sproutapp/pavlov", only: :test},


### PR DESCRIPTION
After opening #27 I thought to myself, "maybe it already works with Scrivener 2 and we just need to relax the dependency?"

So I tried it out and all tests pass with `{:scrivener, "~> 2.0.0"}` in the deps (it also works well in my app, fwiw). This PR relaxes the constraint to let `scrivener_html` run with either version.