### PR TITLE
remove Pavlov in favor of Elixir 1.3’s `describe`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,6 @@ defmodule ScrivenerHtml.Mixfile do
       {:scrivener, "~> 1.2"},
       {:phoenix_html, "~> 2.2"},
       {:phoenix, "~> 1.0 or ~> 1.2", optional: true},
-      {:pavlov, github: "sproutapp/pavlov", only: :test},
       {:ex_doc, "~> 0.10", only: :dev},
       {:earmark, "~> 0.1", only: :dev},
     ]

--- a/test/scrivener/html_test.exs
+++ b/test/scrivener/html_test.exs
@@ -1,213 +1,205 @@
 defmodule Scrivener.HTMLTest do
-  use Pavlov.Case, async: true
+  use ExUnit.Case
   alias Scrivener.HTML
+
   import Scrivener.Support.HTML
   alias Scrivener.Page
 
-  describe "raw_pagination_links" do
+  describe "raw_pagination_links for a page" do
 
-    describe "for a page" do
-
-      it "in the middle" do
-        assert pages(45..55) == links_with_opts total_pages: 100, page_number: 50
-      end
-
-      it ":distance from the first" do
-        assert pages(1..10) == links_with_opts total_pages: 20, page_number: 5
-      end
-
-      it "2 away from the first" do
-        assert pages(1..8) == links_with_opts total_pages: 10, page_number: 3
-      end
-
-      it "1 away from the first" do
-        assert pages(1..7) == links_with_opts total_pages: 10, page_number: 2
-      end
-
-      it "at the first" do
-        assert pages(1..6) == links_with_opts total_pages: 10, page_number: 1
-      end
-
-      it ":distance from the last" do
-        assert pages(10..20) == links_with_opts total_pages: 20, page_number: 15
-      end
-
-      it "2 away from the last" do
-        assert pages(3..10) == links_with_opts total_pages: 10, page_number: 8
-      end
-
-      it "1 away from the last" do
-        assert pages(4..10) == links_with_opts total_pages: 10, page_number: 9
-      end
-
-      it "at the last" do
-        assert pages(5..10) == links_with_opts total_pages: 10, page_number: 10
-      end
-
+    test "in the middle" do
+      assert pages(45..55) == links_with_opts total_pages: 100, page_number: 50
     end
 
-    describe "next" do
-
-      it "includes a next" do
-        assert pages_with_next(45..55, 51) == links_with_opts [total_pages: 100, page_number: 50], next: ">>"
-      end
-
-      it "does not include next when equal to the total" do
-        assert pages(5..10) == links_with_opts [total_pages: 10, page_number: 10], next: ">>"
-      end
-
-      it "can disable next" do
-        assert pages(45..55) == links_with_opts [total_pages: 100, page_number: 50], next: false
-      end
-
+    test ":distance from the first" do
+      assert pages(1..10) == links_with_opts total_pages: 20, page_number: 5
     end
 
-    describe "previous" do
-
-      it "includes a previous" do
-        assert pages_with_previous(49, 45..55) == links_with_opts [total_pages: 100, page_number: 50], previous: "<<"
-      end
-
-      it "includes a previous before the first" do
-        assert [{"<<", 49}, {1, 1}, {:ellipsis, "&hellip;"}] ++ pages(45..55) == links_with_opts [total_pages: 100, page_number: 50], previous: "<<", first: true
-      end
-
-      it "does not include previous when equal to page 1" do
-        assert pages(1..6) == links_with_opts [total_pages: 10, page_number: 1], previous: "<<"
-      end
-
-      it "can disable previous" do
-        assert pages(45..55) == links_with_opts [total_pages: 100, page_number: 50], previous: false
-      end
-
+    test "2 away from the first" do
+      assert pages(1..8) == links_with_opts total_pages: 10, page_number: 3
     end
 
-    describe "first" do
-
-      it "includes the first" do
-        assert pages_with_first(1, 5..15) == links_with_opts [total_pages: 20, page_number: 10], first: true
-      end
-
-      it "does not the include the first when it is already included" do
-        assert pages(1..10) == links_with_opts [total_pages: 10, page_number: 5], first: true
-      end
-
-      it "can disable first" do
-        assert pages(5..15) == links_with_opts [total_pages: 20, page_number: 10], first: false
-      end
-
+    test "1 away from the first" do
+      assert pages(1..7) == links_with_opts total_pages: 10, page_number: 2
     end
 
-    describe "last" do
-
-      it "includes the last" do
-        assert pages_with_last(5..15, 20) == links_with_opts [total_pages: 20, page_number: 10], last: true
-      end
-
-      it "does not the include the last when it is already included" do
-        assert pages(1..10) == links_with_opts [total_pages: 10, page_number: 5], last: true
-      end
-
-      it "can disable last" do
-        assert pages(5..15) == links_with_opts [total_pages: 20, page_number: 10], last: false
-      end
-
+    test "at the first" do
+      assert pages(1..6) == links_with_opts total_pages: 10, page_number: 1
     end
 
-    describe "distance" do
-
-      it "can change the distance" do
-        assert pages(1..3) == links_with_opts [total_pages: 3, page_number: 2], distance: 1
-      end
-
-      it "does not allow negative distances" do
-        assert_raise RuntimeError, "Scrivener.HTML: Distance cannot be less than one.", fn ->
-          links_with_opts [total_pages: 10, page_number: 5], distance: -5
-        end
-      end
-
+    test ":distance from the last" do
+      assert pages(10..20) == links_with_opts total_pages: 20, page_number: 15
     end
 
-    describe "ellipsis" do
-
-      it "includes ellipsis after first" do
-        assert [{1, 1}, {:ellipsis, "&hellip;"}] ++ pages(45..55) == links_with_opts [total_pages: 100, page_number: 50], previous: false, first: true, ellipsis: "&hellip;"
-      end
-
-      it "includes ellipsis before last" do
-        assert pages(5..15) ++ [{:ellipsis, "&hellip;"}, {20, 20}] == links_with_opts [total_pages: 20, page_number: 10], last: true, ellipsis: "&hellip;"
-      end
-
-      it "does not include ellipsis on first page" do
-        assert pages(1..6) == links_with_opts [total_pages: 8, page_number: 1], first: true, ellipsis: "&hellip;"
-      end
-
-      it "uses ellipsis only beyond <distance> of first page" do
-        assert pages(1..11) == links_with_opts [total_pages: 20, page_number: 6], first: true, ellipsis: "&hellip;"
-        assert [{1, 1}, {:ellipsis, "&hellip;"}] ++ pages(2..12) == links_with_opts [total_pages: 20, page_number: 7], first: true, ellipsis: "&hellip;"
-      end
-
-      it "does not include ellipsis on last page" do
-        assert pages(15..20) == links_with_opts [total_pages: 20, page_number: 20], last: true, ellipsis: "&hellip;"
-      end
-
-      it "uses ellipsis only beyond <distance> of last page" do
-        assert pages(10..20) == links_with_opts [total_pages: 20, page_number: 15], last: true, ellipsis: "&hellip;"
-        assert pages(9..19) ++ [{:ellipsis, "&hellip;"}, {20, 20}] == links_with_opts [total_pages: 20, page_number: 14], last: true, ellipsis: "&hellip;"
-      end
-
+    test "2 away from the last" do
+      assert pages(3..10) == links_with_opts total_pages: 10, page_number: 8
     end
+
+    test "1 away from the last" do
+      assert pages(4..10) == links_with_opts total_pages: 10, page_number: 9
+    end
+
+    test "at the last" do
+      assert pages(5..10) == links_with_opts total_pages: 10, page_number: 10
+    end
+
+  end
+
+  describe "raw_pagination_links next" do
+
+    test "includes a next" do
+      assert pages_with_next(45..55, 51) == links_with_opts [total_pages: 100, page_number: 50], next: ">>"
+    end
+
+    test "does not include next when equal to the total" do
+      assert pages(5..10) == links_with_opts [total_pages: 10, page_number: 10], next: ">>"
+    end
+
+    test "can disable next" do
+      assert pages(45..55) == links_with_opts [total_pages: 100, page_number: 50], next: false
+    end
+
+  end
+
+  describe "raw_pagination_links previous" do
+
+    test "includes a previous" do
+      assert pages_with_previous(49, 45..55) == links_with_opts [total_pages: 100, page_number: 50], previous: "<<"
+    end
+
+    test "includes a previous before the first" do
+      assert [{"<<", 49}, {1, 1}, {:ellipsis, "&hellip;"}] ++ pages(45..55) == links_with_opts [total_pages: 100, page_number: 50], previous: "<<", first: true
+    end
+
+    test "does not include previous when equal to page 1" do
+      assert pages(1..6) == links_with_opts [total_pages: 10, page_number: 1], previous: "<<"
+    end
+
+    test "can disable previous" do
+      assert pages(45..55) == links_with_opts [total_pages: 100, page_number: 50], previous: false
+    end
+
+  end
+
+  describe "raw_pagination_links first" do
+
+    test "includes the first" do
+      assert pages_with_first(1, 5..15) == links_with_opts [total_pages: 20, page_number: 10], first: true
+    end
+
+    test "does not the include the first when it is already included" do
+      assert pages(1..10) == links_with_opts [total_pages: 10, page_number: 5], first: true
+    end
+
+    test "can disable first" do
+      assert pages(5..15) == links_with_opts [total_pages: 20, page_number: 10], first: false
+    end
+
+  end
+
+  describe "raw_pagination_links last" do
+
+    test "includes the last" do
+      assert pages_with_last(5..15, 20) == links_with_opts [total_pages: 20, page_number: 10], last: true
+    end
+
+    test "does not the include the last when it is already included" do
+      assert pages(1..10) == links_with_opts [total_pages: 10, page_number: 5], last: true
+    end
+
+    test "can disable last" do
+      assert pages(5..15) == links_with_opts [total_pages: 20, page_number: 10], last: false
+    end
+
+  end
+
+  describe "raw_pagination_links distance" do
+
+    test "can change the distance" do
+      assert pages(1..3) == links_with_opts [total_pages: 3, page_number: 2], distance: 1
+    end
+
+    test "does not allow negative distances" do
+      assert_raise RuntimeError, "Scrivener.HTML: Distance cannot be less than one.", fn ->
+        links_with_opts [total_pages: 10, page_number: 5], distance: -5
+      end
+    end
+
+  end
+
+  describe "raw_pagination_links ellipsis" do
+
+    test "includes ellipsis after first" do
+      assert [{1, 1}, {:ellipsis, "&hellip;"}] ++ pages(45..55) == links_with_opts [total_pages: 100, page_number: 50], previous: false, first: true, ellipsis: "&hellip;"
+    end
+
+    test "includes ellipsis before last" do
+      assert pages(5..15) ++ [{:ellipsis, "&hellip;"}, {20, 20}] == links_with_opts [total_pages: 20, page_number: 10], last: true, ellipsis: "&hellip;"
+    end
+
+    test "does not include ellipsis on first page" do
+      assert pages(1..6) == links_with_opts [total_pages: 8, page_number: 1], first: true, ellipsis: "&hellip;"
+    end
+
+    test "uses ellipsis only beyond <distance> of first page" do
+      assert pages(1..11) == links_with_opts [total_pages: 20, page_number: 6], first: true, ellipsis: "&hellip;"
+      assert [{1, 1}, {:ellipsis, "&hellip;"}] ++ pages(2..12) == links_with_opts [total_pages: 20, page_number: 7], first: true, ellipsis: "&hellip;"
+    end
+
+    test "does not include ellipsis on last page" do
+      assert pages(15..20) == links_with_opts [total_pages: 20, page_number: 20], last: true, ellipsis: "&hellip;"
+    end
+
+    test "uses ellipsis only beyond <distance> of last page" do
+      assert pages(10..20) == links_with_opts [total_pages: 20, page_number: 15], last: true, ellipsis: "&hellip;"
+      assert pages(9..19) ++ [{:ellipsis, "&hellip;"}, {20, 20}] == links_with_opts [total_pages: 20, page_number: 14], last: true, ellipsis: "&hellip;"
+    end
+
   end
 
   describe "pagination_links" do
-    before :each do
+    setup do
       Application.put_env(:scrivener_html, :view_style, :bootstrap)
     end
 
-    it "accepts a paginator and options (same as defaults)" do
+    test "accepts a paginator and options (same as defaults)" do
       assert {:safe, _html} = HTML.pagination_links(%Page{total_pages: 10, page_number: 5}, view_style: :bootstrap, path: &MyApp.Router.Helpers.post_path/3)
     end
 
-    it "supplies defaults" do
+    test "supplies defaults" do
       assert {:safe, _html} = HTML.pagination_links(%Page{total_pages: 10, page_number: 5})
     end
 
-    context "application config" do
-      before :each do
-        Application.put_env(:scrivener_html, :view_style, :another_style)
+    test "uses application config" do
+      Application.put_env(:scrivener_html, :view_style, :another_style)
+      assert_raise RuntimeError, "Scrivener.HTML: View style :another_style is not a valid view style. Please use one of [:bootstrap, :semantic, :foundation]", fn ->
+        HTML.pagination_links(%Page{total_pages: 10, page_number: 5})
       end
-
-      it "uses application config" do
-        assert_raise RuntimeError, "Scrivener.HTML: View style :another_style is not a valid view style. Please use one of [:bootstrap, :semantic, :foundation]", fn ->
-          HTML.pagination_links(%Page{total_pages: 10, page_number: 5})
-        end
-      end
-
     end
 
-    it "allows options in any order" do
+    test "allows options in any order" do
       assert {:safe, _html} = HTML.pagination_links(%Page{total_pages: 10, page_number: 5}, view_style: :bootstrap, path: &MyApp.Router.Helpers.post_path/3)
     end
 
-    it "errors for unsupported view styles" do
+    test "errors for unsupported view styles" do
       assert_raise RuntimeError, fn ->
         HTML.pagination_links(%Page{total_pages: 10, page_number: 5}, view_style: :unknown)
       end
     end
 
-    it "accepts an override action" do
+    test "accepts an override action" do
       html = HTML.pagination_links(%Page{total_pages: 10, page_number: 5}, view_style: :bootstrap, action: :edit, path: &MyApp.Router.Helpers.post_path/3)
       assert Phoenix.HTML.safe_to_string(html) =~ ~r(\/posts\/:id\/edit)
     end
 
-    it "accepts an override page param name" do
+    test "accepts an override page param name" do
       html = HTML.pagination_links(%Page{total_pages: 2, page_number: 2}, page_param: :custom_pp)
       assert Phoenix.HTML.safe_to_string(html) =~ ~r(custom_pp=2)
     end
   end
 
   describe "Phoenix conn()" do
-    it "handles no entries" do
+    test "handles no entries" do
       use Phoenix.ConnTest
       Application.put_env(:scrivener_html, :view_style, :bootstrap)
       Application.put_env(:scrivener_html, :routes_helper, MyApp.Router.Helpers)
@@ -221,53 +213,51 @@ defmodule Scrivener.HTMLTest do
     end
   end
 
-  describe "alternative view styles" do
-    describe "Semantic UI" do
-      it "renders Semantic UI styling" do
-        use Phoenix.ConnTest
-        Application.put_env(:scrivener_html, :view_style, :semantic)
-        Application.put_env(:scrivener_html, :routes_helper, MyApp.Router.Helpers)
+  describe "Semantic UI" do
+    test "renders Semantic UI styling" do
+      use Phoenix.ConnTest
+      Application.put_env(:scrivener_html, :view_style, :semantic)
+      Application.put_env(:scrivener_html, :routes_helper, MyApp.Router.Helpers)
 
-        assert {:safe, ["<div class=\"ui pagination menu\">",
-                        [["<a class=\"active item\">", "1", "</a>"]],
-                      "</div>"]} =
-          HTML.pagination_links(build_conn(), %Page{entries: [], page_number: 1, page_size: 10, total_entries: 0, total_pages: 0})
-      end
+      assert {:safe, ["<div class=\"ui pagination menu\">",
+                      [["<a class=\"active item\">", "1", "</a>"]],
+                    "</div>"]} =
+        HTML.pagination_links(build_conn(), %Page{entries: [], page_number: 1, page_size: 10, total_entries: 0, total_pages: 0})
+    end
+  end
+
+  describe "Foundation for Sites 6.x" do
+    test "renders Foundation for Sites 6.x styling" do
+      use Phoenix.ConnTest
+      Application.put_env(:scrivener_html, :view_style, :foundation)
+      Application.put_env(:scrivener_html, :routes_helper, MyApp.Router.Helpers)
+
+      assert {:safe, ["<ul class=\"pagination\" role=\"pagination\">",
+                      [["<li class=\"current\">", ["<span class=\"\">", "1", "</span>"], "</li>"],
+                       ["<li class=\"\">", ["<span class=\"\">", "2", "</span>"], "</li>"],
+                       ["<li class=\"\">", ["<span class=\"\">", "&gt;&gt;", "</span>"], "</li>"]], "</ul>"]} =
+        HTML.pagination_links(build_conn(), %Page{entries: [], page_number: 1, page_size: 10, total_entries: 20, total_pages: 2})
     end
 
-    describe "Foundation for Sites 6.x" do
-      it "renders Foundation for Sites 6.x styling" do
-        use Phoenix.ConnTest
-        Application.put_env(:scrivener_html, :view_style, :foundation)
-        Application.put_env(:scrivener_html, :routes_helper, MyApp.Router.Helpers)
+    test "renders Foundation for Sites 6.x styling with ellipsis" do
+      use Phoenix.ConnTest
+      Application.put_env(:scrivener_html, :view_style, :foundation)
+      Application.put_env(:scrivener_html, :routes_helper, MyApp.Router.Helpers)
 
-        assert {:safe, ["<ul class=\"pagination\" role=\"pagination\">",
-                        [["<li class=\"current\">", ["<span class=\"\">", "1", "</span>"], "</li>"],
-                         ["<li class=\"\">", ["<span class=\"\">", "2", "</span>"], "</li>"],
-                         ["<li class=\"\">", ["<span class=\"\">", "&gt;&gt;", "</span>"], "</li>"]], "</ul>"]} =
-          HTML.pagination_links(build_conn(), %Page{entries: [], page_number: 1, page_size: 10, total_entries: 20, total_pages: 2})
-      end
-
-      it "renders Foundation for Sites 6.x styling with ellipsis" do
-        use Phoenix.ConnTest
-        Application.put_env(:scrivener_html, :view_style, :foundation)
-        Application.put_env(:scrivener_html, :routes_helper, MyApp.Router.Helpers)
-
-        assert {:safe, ["<ul class=\"pagination\" role=\"pagination\">",
-                        [["<li class=\"\">", ["<span class=\"\">", "&lt;&lt;", "</span>"], "</li>"],
-                         ["<li class=\"\">", ["<span class=\"\">", "1", "</span>"], "</li>"],
-                         ["<li class=\"\">", ["<span class=\"\">", "2", "</span>"], "</li>"],
-                         ["<li class=\"current\">", ["<span class=\"\">", "3", "</span>"], "</li>"],
-                         ["<li class=\"\">", ["<span class=\"\">", "4", "</span>"], "</li>"],
-                         ["<li class=\"\">", ["<span class=\"\">", "5", "</span>"], "</li>"],
-                         ["<li class=\"\">", ["<span class=\"\">", "6", "</span>"], "</li>"],
-                         ["<li class=\"\">", ["<span class=\"\">", "7", "</span>"], "</li>"],
-                         ["<li class=\"\">", ["<span class=\"\">", "8", "</span>"], "</li>"],
-                         ["<li class=\"ellipsis\">", ["<span class=\"\">", "&hellip;", "</span>"], "</li>"],
-                         ["<li class=\"\">", ["<span class=\"\">", "10", "</span>"], "</li>"],
-                         ["<li class=\"\">", ["<span class=\"\">", "&gt;&gt;", "</span>"], "</li>"]], "</ul>"]} ==
-          HTML.pagination_links(build_conn(), %Page{entries: [], page_number: 3, page_size: 10, total_entries: 100, total_pages: 10}, [], ellipsis: true)
-      end
+      assert {:safe, ["<ul class=\"pagination\" role=\"pagination\">",
+                      [["<li class=\"\">", ["<span class=\"\">", "&lt;&lt;", "</span>"], "</li>"],
+                       ["<li class=\"\">", ["<span class=\"\">", "1", "</span>"], "</li>"],
+                       ["<li class=\"\">", ["<span class=\"\">", "2", "</span>"], "</li>"],
+                       ["<li class=\"current\">", ["<span class=\"\">", "3", "</span>"], "</li>"],
+                       ["<li class=\"\">", ["<span class=\"\">", "4", "</span>"], "</li>"],
+                       ["<li class=\"\">", ["<span class=\"\">", "5", "</span>"], "</li>"],
+                       ["<li class=\"\">", ["<span class=\"\">", "6", "</span>"], "</li>"],
+                       ["<li class=\"\">", ["<span class=\"\">", "7", "</span>"], "</li>"],
+                       ["<li class=\"\">", ["<span class=\"\">", "8", "</span>"], "</li>"],
+                       ["<li class=\"ellipsis\">", ["<span class=\"\">", "&hellip;", "</span>"], "</li>"],
+                       ["<li class=\"\">", ["<span class=\"\">", "10", "</span>"], "</li>"],
+                       ["<li class=\"\">", ["<span class=\"\">", "&gt;&gt;", "</span>"], "</li>"]], "</ul>"]} ==
+        HTML.pagination_links(build_conn(), %Page{entries: [], page_number: 3, page_size: 10, total_entries: 100, total_pages: 10}, [], ellipsis: true)
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,1 @@
 ExUnit.start()
-Pavlov.start


### PR DESCRIPTION
Elixir 1.3 adds describe functionality to ExUnit, which conflicts w/ Pavlov and breaks the test suite. Here's the changes necessary to remove Pavlov and use 1.3's describe instead.

You probably won't need this until you're ready to go Elixir 1.3 only, but I made these changes when running the tests for #28 and I figured I'd at least create the PR to save you the effort when you get there.

