### PR TITLE
Loosen scrivener 2.0 version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule ScrivenerHtml.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:scrivener, "~> 1.2 or ~> 2.0.0"},
+      {:scrivener, "~> 1.2 or ~> 2.0"},
       {:phoenix_html, "~> 2.2"},
       {:phoenix, "~> 1.0 or ~> 1.2", optional: true},
       {:ex_doc, "~> 0.10", only: :dev},


### PR DESCRIPTION
This allows `scrivener_html` to work with the newer versions of `scrivener` (`2.1.x`).