### PR TITLE
adding support for params defined with a keyword list

### DIFF
--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -37,9 +37,7 @@ defmodule Scrivener.HTML do
     resolution cannot be performed.
     """
     def path(_conn, :index, opts) do
-      Enum.reduce opts, "?", fn {k, v}, s ->
-        "#{s}#{if(s == "?", do: "", else: "&")}#{k}=#{v}"
-      end
+      "?" <> Plug.Conn.Query.encode(opts)
     end
   end
 

--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -37,7 +37,7 @@ defmodule Scrivener.HTML do
     resolution cannot be performed.
     """
     def path(_conn, :index, opts) do
-      "?" <> Plug.Conn.Query.encode(opts)
+      ("?" <> Plug.Conn.Query.encode(opts))
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -48,6 +48,7 @@ defmodule ScrivenerHtml.Mixfile do
       {:scrivener, "~> 1.2 or ~> 2.0"},
       {:phoenix_html, "~> 2.2"},
       {:phoenix, "~> 1.0 or ~> 1.2", optional: true},
+      {:plug, "~>1.1" },
       {:ex_doc, "~> 0.10", only: :dev},
       {:earmark, "~> 0.1", only: :dev},
     ]

--- a/test/scrivener/html_test.exs
+++ b/test/scrivener/html_test.exs
@@ -210,6 +210,11 @@ defmodule Scrivener.HTMLTest do
       <nav><ul class=\"pagination\"><li class=\"\"><a class=\"\" href=\"?page=1\">&leftarrow;</a></li><li class=\"\"><a class=\"\" href=\"?page=1\">1</a></li><li class=\"active\"><a class=\"\" href=\"?page=2\">2</a></li></ul></nav>
       """ |> String.trim_trailing
     end
+
+    test "accept nested keyword list for additionnal params" do
+      html = HTML.pagination_links(%Page{total_pages: 2, page_number: 2}, q: [name: "joe"])
+      assert Phoenix.HTML.safe_to_string(html) =~ ~r(q\[name\]=joe)
+    end
   end
 
   describe "Phoenix conn()" do


### PR DESCRIPTION
I was trying to pass a nested keyword list as a query param to the pagination_links function:

```
pagination_links(@orders, [q: [name: "joe"]])
```
I was getting the following error:

```
** (exit) an exception was raised:
    ** (ArgumentError) cannot convert the given list to a string.

To be converted to a string, a list must contain only:

  * strings
  * integers representing Unicode codepoints
  * or a list containing one of these three elements

Please check the given list or call inspect/1 to get the list representation, got:

[name: "joe"]

        (elixir) lib/list.ex:624: List.to_string/1
        (scrivener_html) lib/scrivener/html.ex:41: anonymous fn/2 in Scrivener.HTML.Default.path/3
```
I replaced the code that generates the query params by the `Plug.Conn.Query.encode` function. I think it will make the function more generic.

I hope that this makes sense.