### PR TITLE
Fix warnings Elixir 1.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,9 +17,9 @@ defmodule ScrivenerHtml.Mixfile do
        main: Scrivener.HTML,
        readme: "README.md"
      ],
-     package: package,
-     deps: deps,
-     aliases: aliases]
+     package: package(),
+     deps: deps(),
+     aliases: aliases()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
scrivener_html/mix.exs:20

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
scrivener_html/mix.exs:21

warning: variable "aliases" does not exist and is being expanded to "aliases()", please use parentheses to remove the ambiguity or change the variable name
scrivener_html/mix.exs:22