### PR TITLE
Fix bug for extra ellipsis when using first/last

### DIFF
--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -282,10 +282,10 @@ defmodule Scrivener.HTML do
     options = Keyword.merge @raw_defaults, options
 
     add_first(paginator.page_number, options[:distance], options[:first])
-    |> add_first_ellipsis(paginator.page_number, paginator.total_pages, options[:distance])
+    |> add_first_ellipsis(paginator.page_number, paginator.total_pages, options[:distance], options[:first])
     |> add_previous(paginator.page_number)
     |> page_number_list(paginator.page_number, paginator.total_pages, options[:distance])
-    |> add_last_ellipsis(paginator.page_number, paginator.total_pages, options[:distance])
+    |> add_last_ellipsis(paginator.page_number, paginator.total_pages, options[:distance], options[:last])
     |> add_last(paginator.page_number, paginator.total_pages, options[:distance], options[:last])
     |> add_next(paginator.page_number, paginator.total_pages)
     |> Enum.map(fn
@@ -353,17 +353,25 @@ defmodule Scrivener.HTML do
     list
   end
 
-  defp add_first_ellipsis(list, page, _total, distance) when page - distance > 1 and page > 1 do
+  defp add_first_ellipsis(list, page, total, distance, true) do
+    add_first_ellipsis(list, page,total, distance + 1, nil)
+  end
+
+  defp add_first_ellipsis(list, page, _total, distance, _first) when page - distance > 1 and page > 1 do
     list ++ [:first_ellipsis]
   end
-  defp add_first_ellipsis(list, _page_number, _total, _distance) do
+  defp add_first_ellipsis(list, _page_number, _total, _distance, _first) do
     list
   end
 
-  defp add_last_ellipsis(list, page, total, distance) when page + distance < total and page != total do
+  defp add_last_ellipsis(list, page, total, distance, true) do
+    add_last_ellipsis(list, page, total, distance + 1, nil)
+  end
+
+  defp add_last_ellipsis(list, page, total, distance, _) when page + distance < total and page != total do
     list ++ [:last_ellipsis]
   end
-  defp add_last_ellipsis(list, _page_number, _total, _distance) do
+  defp add_last_ellipsis(list, _page_number, _total, _distance, _last) do
     list
   end
 

--- a/test/scrivener/html_test.exs
+++ b/test/scrivener/html_test.exs
@@ -146,6 +146,13 @@ defmodule Scrivener.HTMLTest do
       assert [{1, 1}, {:ellipsis, "&hellip;"}] ++ pages(2..12) == links_with_opts [total_pages: 20, page_number: 7], first: true, ellipsis: "&hellip;"
     end
 
+    test "when first/last are true, uses ellipsis only when (<distance> + 1) is greater than the total pages" do
+      options = [first: true, last: true, distance: 1]
+
+      assert pages(1..3) == links_with_opts [total_pages: 3, page_number: 1], options
+      assert pages(1..3) == links_with_opts [total_pages: 3, page_number: 3], options
+    end
+
     test "does not include ellipsis on last page" do
       assert pages(15..20) == links_with_opts [total_pages: 20, page_number: 20], last: true, ellipsis: "&hellip;"
     end


### PR DESCRIPTION
If you use first/last, then the "distance" required before showing
an ellipsis should be one greater than the current implementation.

Example of bug:
If you have 3 total pages, using first/last true (which is the default)
and you're on page 1, you're links would be 1, 2, ..3