### PR TITLE
Elixir 1.4 -- Keyword.merge/2 throws exception on improper keyword list

### DIFF
--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -203,7 +203,7 @@ defmodule Scrivener.HTML do
   end
 
   defp page({text, page_number}, url_params, args, page_param, path, paginator, :semantic) do
-    params_with_page = Keyword.merge(url_params, [{page_param, page_number}])
+    params_with_page = url_params ++ [{page_param, page_number}]
     to = apply(path, args ++ [params_with_page])
     if to do
       link(safe(text), to: to, class: li_classes_for_style(paginator, page_number, :semantic) |> Enum.join(" "))
@@ -212,7 +212,7 @@ defmodule Scrivener.HTML do
     end
   end
   defp page({text, page_number}, url_params, args, page_param, path, paginator, style) do
-    params_with_page = Keyword.merge(url_params, [{page_param, page_number}])
+    params_with_page = url_params ++ [{page_param, page_number}]
     content_tag :li, class: li_classes_for_style(paginator, page_number, style) |> Enum.join(" ") do
       to = apply(path, args ++ [params_with_page])
       if to do


### PR DESCRIPTION
Fixes #50 

@nlap I don't know what else to do except `++` these two lists together since one will most definately be a true keyword list and the other won't. The other option was to try to turn the second list into a true keyword list, but that would mean converting `page_param` into an atom when it is already an integer. This to me seems more dangerous because of the number of atoms it could create. Seems the lesser of two evils is to use `++`.