### PR TITLE
add bulma 0.4.x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ To show icons instead of text, simply render custom html templates, like:
 And in prev_link.html.eex (this example use materialize icons)
 <i class="material-icons">chevron_left</i>
 
-There are five view styles currently supported:
+There are six view styles currently supported:
 
 - `:bootstrap` (the default) This styles the pagination links in a manner that
   is expected by Bootstrap 3.x.
@@ -144,6 +144,7 @@ There are five view styles currently supported:
   is expected by Bootstrap 4.x.
 - `:materialize` This styles the pagination links in a manner that
   is expected by Materialize css 0.x.
+- `:bulma` This styles the pagination links in a manner that is expected by Bulma 0.4.x, using the `is-centered` as a default.
 
 For custom HTML output, see `Scrivener.HTML.raw_pagination_links/2`.
 

--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -1,7 +1,7 @@
 defmodule Scrivener.HTML do
   use Phoenix.HTML
   @defaults [view_style: :bootstrap, action: :index, page_param: :page]
-  @view_styles [:bootstrap, :semantic, :foundation, :bootstrap_v4, :materialize]
+  @view_styles [:bootstrap, :semantic, :foundation, :bootstrap_v4, :materialize, :bulma]
   @raw_defaults [distance: 5, next: ">>", previous: "<<", first: true, last: true, ellipsis: raw("&hellip;")]
   @moduledoc """
   For use with Phoenix.HTML, configure the `:routes_helper` module like the following:
@@ -188,6 +188,17 @@ defmodule Scrivener.HTML do
     end
   end
 
+  # Bulma implementation
+  defp _pagination_links(paginator, [view_style: :bulma, path: path, args: args, page_param: page_param, params: params]) do
+    url_params = Keyword.drop params, Keyword.keys(@raw_defaults)
+    content_tag :nav, class: "pagination is-centered" do
+      content_tag :ul, class: "pagination-list" do
+        raw_pagination_links(paginator, params)
+        |> Enum.map(&page(&1, url_params, args, page_param, path, paginator, :bulma))
+      end
+    end
+  end
+
   defp page({:ellipsis, true}, url_params, args, page_param, path, paginator, style) do
     page({:ellipsis, unquote(@raw_defaults[:ellipsis])}, url_params, args, page_param, path, paginator, style)
   end
@@ -246,13 +257,20 @@ defmodule Scrivener.HTML do
   defp li_classes_for_style(paginator, page_number, :materialize) do
     if(paginator.page_number == page_number, do: ["active"], else: ["waves-effect"])
   end
+  defp li_classes_for_style(_paginator, :ellipsis, :bulma), do: []
+  defp li_classes_for_style(_paginator, _page_number, :bulma), do: []
 
   defp link_classes_for_style(_paginator, _page_number, :bootstrap), do: []
   defp link_classes_for_style(_paginator, _page_number, :bootstrap_v4), do: ["page-link"]
   defp link_classes_for_style(_paginator, _page_number, :foundation), do: []
   defp link_classes_for_style(_paginator, _page_number, :materialize), do: []
+  defp link_classes_for_style(paginator, page_number, :bulma) do
+    if(paginator.page_number == page_number, do: ["pagination-link", "is-current"], else: ["pagination-link"])
+  end
+
   defp link_classes_for_style(_paginator, :ellipsis, :semantic), do: ["disabled", "item"]
   defp link_classes_for_style(_paginator, :ellipsis, :materialize), do: []
+  defp link_classes_for_style(_paginator, :ellipsis, :bulma), do: ["pagination-ellipsis"]
 
   defp ellipsis_tag(:semantic), do: :div
   defp ellipsis_tag(_), do: :span

--- a/test/scrivener/html_test.exs
+++ b/test/scrivener/html_test.exs
@@ -183,7 +183,7 @@ defmodule Scrivener.HTMLTest do
 
     test "uses application config" do
       Application.put_env(:scrivener_html, :view_style, :another_style)
-      assert_raise RuntimeError, "Scrivener.HTML: View style :another_style is not a valid view style. Please use one of [:bootstrap, :semantic, :foundation, :bootstrap_v4, :materialize]", fn ->
+      assert_raise RuntimeError, "Scrivener.HTML: View style :another_style is not a valid view style. Please use one of [:bootstrap, :semantic, :foundation, :bootstrap_v4, :materialize, :bulma]", fn ->
         HTML.pagination_links(%Page{total_pages: 10, page_number: 5})
       end
     end
@@ -397,7 +397,7 @@ defmodule Scrivener.HTMLTest do
     end
   end
 
-    describe "Materialize css" do
+  describe "Materialize css" do
     test "renders materialize css styling" do
       use Phoenix.ConnTest
       Application.put_env(:scrivener_html, :view_style, :materialize)
@@ -417,4 +417,22 @@ defmodule Scrivener.HTMLTest do
     end
   end
 
+  describe "Bulma css" do
+    test "renders bulma css styling" do
+      use Phoenix.ConnTest
+      Application.put_env(:scrivener_html, :view_style, :bulma)
+      Application.put_env(:scrivener_html, :routes_helper, MyApp.Router.Helpers)
+
+      assert(
+        {:safe, [60, "nav", [[32, "class", 61, 34, "pagination is-centered", 34]], 62,
+          [60, "ul", [[32, "class", 61, 34, "pagination-list", 34]], 62,
+            [[60, "li", [[32, "class", 61, 34, "", 34]], 62,
+            [60, "a", [[32, "class", 61, 34, "pagination-link is-current", 34]], 62, "1", 60, 47, "a", 62], 60, 47,
+            "li", 62], [60, "li", [[32, "class", 61, 34, "", 34]], 62, [60, "a", [[32, "class", 61, 34, "pagination-link", 34]],
+            62, "2", 60, 47, "a", 62], 60, 47, "li", 62], [60, "li", [[32, "class", 61, 34, "", 34]], 62, [60, "a", [[32, "class", 61, 34, "pagination-link", 34]],
+            62, "&gt;&gt;", 60, 47, "a", 62], 60, 47, "li", 62]], 60, 47, "ul", 62], 60, 47, "nav", 62]
+        }
+      ) == HTML.pagination_links(build_conn(), %Page{entries: [], page_number: 1, page_size: 10, total_entries: 2, total_pages: 2})
+    end
+  end
 end


### PR DESCRIPTION
As the other branch has seem to go stale & the css/classes is out of date to the current version of Bulma, here is the updated version.

I've opted to use the default `is-centered` as described here ~ http://bulma.io/documentation/components/pagination/
As it allow's for the `ellipsis` to sit nicely within the list without the need for the outside the ul elements
<img width="585" alt="screen shot 2017-03-21 at 17 37 45" src="https://cloud.githubusercontent.com/assets/1747026/24161876/8e13cc56-0e5d-11e7-9807-a581a4617473.png">

This is an example from my current Phoenix app.

Let me know if there is anything else i need to add :-)

B
