### PR TITLE
Updated usage of "not expr1 in expr2" to support Elixir 1.5+

### DIFF
--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -133,7 +133,7 @@ defmodule Scrivener.HTML do
     "#{acc}#{if(acc != "", do: "_")}#{Phoenix.Naming.resource_name(model.__struct__)}"
   end
 
-  defp _pagination_links(_paginator, [view_style: style, path: _path, args: _args, page_param: _page_param, params: _params]) when not style in @view_styles do
+  defp _pagination_links(_paginator, [view_style: style, path: _path, args: _args, page_param: _page_param, params: _params]) when not (style in @view_styles) do
     raise "Scrivener.HTML: View style #{inspect style} is not a valid view style. Please use one of #{inspect @view_styles}"
   end
 


### PR DESCRIPTION
Elixir 1.5+ shall be deprecating this operation.
I just added parentheses to fix this and also support earlier Elixir versions.

See the reported warning below:
"not expr1 in expr2" is deprecated. Instead use "expr1 not in expr2" if you require Elixir v1.5+, or "not(expr1 in expr2)" if you have to support earlier Elixir versions.