### PR TITLE
Always use `li_classes_for_style/3` for :semantic links

### DIFF
--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -219,7 +219,7 @@ defmodule Scrivener.HTML do
     to = apply(path, args ++ [params_with_page])
     if to do
       if active_page?(paginator, page_number) do
-        content_tag(:a, safe(text), class: link_classes_for_style(paginator, page_number, :semantic) |> Enum.join(" "))
+        content_tag(:a, safe(text), class: li_classes_for_style(paginator, page_number, :semantic) |> Enum.join(" "))
       else
         link(safe(text), to: to, rel: Scrivener.HTML.SEO.rel(paginator, page_number), class: li_classes_for_style(paginator, page_number, :semantic) |> Enum.join(" "))
       end


### PR DESCRIPTION
There is no `link_classes_for_style/3` that matches `:semantic` view style, so we need to always use `li_classes_for_style/3`.

I tried writing a test for this, but couldn't figure out how to pass the right data in so that the `to` variable contains data, which would trigger this particular code. If you show me how to do that happy to add it.