### PR TITLE
Add option to hide pagination for single page result

### DIFF
--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -1,6 +1,6 @@
 defmodule Scrivener.HTML do
   use Phoenix.HTML
-  @defaults [view_style: :bootstrap, action: :index, page_param: :page]
+  @defaults [view_style: :bootstrap, action: :index, page_param: :page, hide_single: false]
   @view_styles [:bootstrap, :semantic, :foundation, :bootstrap_v4, :materialize, :bulma]
   @raw_defaults [
     distance: 5,
@@ -119,7 +119,9 @@ defmodule Scrivener.HTML do
 
     hide_single_result = opts[:hide_single] && paginator.total_pages < 2
 
-    unless hide_single_result do
+    if hide_single_result do
+      Phoenix.HTML.raw(nil)
+    else
       # Ensure ordering so pattern matching is reliable
       _pagination_links(paginator,
         view_style: merged_opts[:view_style],
@@ -128,8 +130,6 @@ defmodule Scrivener.HTML do
         page_param: merged_opts[:page_param],
         params: params
       )
-    else
-      Phoenix.HTML.raw(nil)
     end
   end
 

--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -107,20 +107,30 @@ defmodule Scrivener.HTML do
         view_style:
           opts[:view_style] || Application.get_env(:scrivener_html, :view_style, :bootstrap)
       )
+      |> Keyword.merge(
+        hide_single:
+          opts[:hide_single] || Application.get_env(:scrivener_html, :hide_single, false)
+      )
 
     merged_opts = Keyword.merge(@defaults, opts)
 
     path = opts[:path] || find_path_fn(conn && paginator.entries, args)
-    params = Keyword.drop(opts, Keyword.keys(@defaults) ++ [:path])
+    params = Keyword.drop(opts, Keyword.keys(@defaults) ++ [:path, :hide_single])
 
-    # Ensure ordering so pattern matching is reliable
-    _pagination_links(paginator,
-      view_style: merged_opts[:view_style],
-      path: path,
-      args: [conn, merged_opts[:action]] ++ args,
-      page_param: merged_opts[:page_param],
-      params: params
-    )
+    hide_single_result = opts[:hide_single] && paginator.total_pages < 2
+
+    unless hide_single_result do
+      # Ensure ordering so pattern matching is reliable
+      _pagination_links(paginator,
+        view_style: merged_opts[:view_style],
+        path: path,
+        args: [conn, merged_opts[:action]] ++ args,
+        page_param: merged_opts[:page_param],
+        params: params
+      )
+    else
+      Phoenix.HTML.raw(nil)
+    end
   end
 
   def pagination_links(%Scrivener.Page{} = paginator),

--- a/test/scrivener/html_test.exs
+++ b/test/scrivener/html_test.exs
@@ -293,6 +293,27 @@ defmodule Scrivener.HTMLTest do
       html = HTML.pagination_links(%Page{total_pages: 2, page_number: 2}, q: [name: "joe"])
       assert Phoenix.HTML.safe_to_string(html) =~ ~r(q\[name\]=joe)
     end
+
+    test "hide single page result from option" do
+      html =
+        HTML.pagination_links(%Page{total_pages: 1, page_number: 1},
+          q: [name: "joe"],
+          hide_single: true
+        )
+
+      assert Phoenix.HTML.safe_to_string(html) == ""
+    end
+
+    test "show pagination when there are multiple pages" do
+      html =
+        HTML.pagination_links(%Page{total_pages: 2, page_number: 1},
+          q: [name: "joe"],
+          hide_single: true
+        )
+
+      assert Phoenix.HTML.safe_to_string(html) ==
+               "<nav><ul class=\"pagination\"><li class=\"active\"><a class=\"\">1</a></li><li class=\"\"><a class=\"\" href=\"?q[name]=joe&amp;page=2\" rel=\"next\">2</a></li><li class=\"\"><a class=\"\" href=\"?q[name]=joe&amp;page=2\" rel=\"next\">&gt;&gt;</a></li></ul></nav>"
+    end
   end
 
   describe "Phoenix conn()" do


### PR DESCRIPTION
I need to hide pagination when total pages are one/zero. There is also related issue here, https://github.com/mgwidmann/scrivener_html/issues/75.

This PR adds a global option with key `hide_single` or you can set it as an option in `pagination_links` function i.e. `pagination_links(conn, page, hide_single: true)`. (also open to change the option to a different name, can't think of a better name at the moment).

All tests are passing. Let me know if this is something you like or don't like. I'm okay with either decision. I can definitely hide the pagination in the template, but it's probably convenient to have it as an option.