### PR TITLE
fix: source_url in Mix file

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule ScrivenerHtml.Mixfile do
       version: @version,
       elixir: "~> 1.2",
       name: "scrivener_html",
-      source_url: "git@github.com:mgwidmann/scrivener_html.git",
+      source_url: "https://github.com/mgwidmann/scrivener_html",
       homepage_url: "https://github.com/mgwidmann/scrivener_html",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
The `source_url` needs to be an url.

This fixes the "View Source" buttons url in on hexdocs.pm that previously was `git@github.com:mgwidmann/scrivener_html.git`

The `View Source` button:
<img width="970" alt="Screenshot 2019-04-03 at 12 48 04" src="https://user-images.githubusercontent.com/16062635/55476924-b99bbb80-560f-11e9-8775-b3dfa77324c3.png">

It's url:
<img width="927" alt="Screenshot 2019-04-03 at 12 49 07" src="https://user-images.githubusercontent.com/16062635/55476925-b99bbb80-560f-11e9-9b2e-b666677a818d.png">
