### PR TITLE
Add custom link function

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ If you need to hit a different action other than `:index`, simply pass the actio
 <%= pagination_links @conn, @page, action: :show %>
 ```
 
+### Custom Link Function
+
+Set `:link_fun` to any function with arity 2. Defaults to `Phoenix.HTML.link/2`.
+
+```elixir
+<%= pagination_links @conn, @page, link_fun: &live_link/2 %>
+```
+
 ### Customizing Output
 
 Below are the defaults which are used without passing in any options.

--- a/lib/scrivener/html.ex
+++ b/lib/scrivener/html.ex
@@ -112,24 +112,31 @@ defmodule Scrivener.HTML do
           opts[:hide_single] || Application.get_env(:scrivener_html, :hide_single, false)
       )
 
+    link_fun = opts[:link_fun] || Application.get_env(:scrivener_html, :link_fun, &link/2)
+
     merged_opts = Keyword.merge(@defaults, opts)
 
     path = opts[:path] || find_path_fn(conn && paginator.entries, args)
-    params = Keyword.drop(opts, Keyword.keys(@defaults) ++ [:path, :hide_single])
+    params = Keyword.drop(opts, Keyword.keys(@defaults) ++ [:path, :hide_single, :link_fun])
 
     hide_single_result = opts[:hide_single] && paginator.total_pages < 2
+
+    url_params = Keyword.drop(params, Keyword.keys(@raw_defaults))
+
+    page_opts = %{
+      paginator: paginator,
+      url_params: url_params,
+      path: path,
+      args: [conn, merged_opts[:action]] ++ args,
+      page_param: merged_opts[:page_param],
+      link_fun: link_fun
+    }
 
     if hide_single_result do
       Phoenix.HTML.raw(nil)
     else
       # Ensure ordering so pattern matching is reliable
-      _pagination_links(paginator,
-        view_style: merged_opts[:view_style],
-        path: path,
-        args: [conn, merged_opts[:action]] ++ args,
-        page_param: merged_opts[:page_param],
-        params: params
-      )
+      _pagination_links(merged_opts[:view_style], params, page_opts)
     end
   end
 
@@ -178,13 +185,7 @@ defmodule Scrivener.HTML do
     "#{acc}#{if(acc != "", do: "_")}#{Phoenix.Naming.resource_name(model.__struct__)}"
   end
 
-  defp _pagination_links(_paginator,
-         view_style: style,
-         path: _path,
-         args: _args,
-         page_param: _page_param,
-         params: _params
-       )
+  defp _pagination_links(style, _params, _opts)
        when not (style in @view_styles) do
     raise "Scrivener.HTML: View style #{inspect(style)} is not a valid view style. Please use one of #{
             inspect(@view_styles)
@@ -192,130 +193,75 @@ defmodule Scrivener.HTML do
   end
 
   # Bootstrap implementation
-  defp _pagination_links(paginator,
-         view_style: :bootstrap,
-         path: path,
-         args: args,
-         page_param: page_param,
-         params: params
-       ) do
-    url_params = Keyword.drop(params, Keyword.keys(@raw_defaults))
-
+  defp _pagination_links(:bootstrap, params, page_opts) do
     content_tag :nav do
       content_tag :ul, class: "pagination" do
-        raw_pagination_links(paginator, params)
-        |> Enum.map(&page(&1, url_params, args, page_param, path, paginator, :bootstrap))
+        raw_pagination_links(page_opts.paginator, params)
+        |> Enum.map(&page(&1, page_opts, :bootstrap))
       end
     end
   end
 
   # Bootstrap implementation
-  defp _pagination_links(paginator,
-         view_style: :bootstrap_v4,
-         path: path,
-         args: args,
-         page_param: page_param,
-         params: params
-       ) do
-    url_params = Keyword.drop(params, Keyword.keys(@raw_defaults))
-
+  defp _pagination_links(:bootstrap_v4, params, page_opts) do
     content_tag :nav, "aria-label": "Page navigation" do
       content_tag :ul, class: "pagination" do
-        raw_pagination_links(paginator, params)
-        |> Enum.map(&page(&1, url_params, args, page_param, path, paginator, :bootstrap_v4))
+        raw_pagination_links(page_opts.paginator, params)
+        |> Enum.map(&page(&1, page_opts, :bootstrap_v4))
       end
     end
   end
 
   # Semantic UI implementation
-  defp _pagination_links(paginator,
-         view_style: :semantic,
-         path: path,
-         args: args,
-         page_param: page_param,
-         params: params
-       ) do
-    url_params = Keyword.drop(params, Keyword.keys(@raw_defaults))
-
+  defp _pagination_links(:semantic, params, page_opts) do
     content_tag :div, class: "ui pagination menu" do
-      raw_pagination_links(paginator, params)
-      |> Enum.map(&page(&1, url_params, args, page_param, path, paginator, :semantic))
+      raw_pagination_links(page_opts.paginator, params)
+      |> Enum.map(&page(&1, page_opts, :semantic))
     end
   end
 
   # Foundation for Sites 6.x implementation
-  defp _pagination_links(paginator,
-         view_style: :foundation,
-         path: path,
-         args: args,
-         page_param: page_param,
-         params: params
-       ) do
-    url_params = Keyword.drop(params, Keyword.keys(@raw_defaults))
-
+  defp _pagination_links(:foundation, params, page_opts) do
     content_tag :ul, class: "pagination", role: "pagination" do
-      raw_pagination_links(paginator, params)
-      |> Enum.map(&page(&1, url_params, args, page_param, path, paginator, :foundation))
+      raw_pagination_links(page_opts.paginator, params)
+      |> Enum.map(&page(&1, page_opts, :foundation))
     end
   end
 
   # Materialized implementation
-  defp _pagination_links(paginator,
-         view_style: :materialize,
-         path: path,
-         args: args,
-         page_param: page_param,
-         params: params
-       ) do
-    url_params = Keyword.drop(params, Keyword.keys(@raw_defaults))
-
+  defp _pagination_links(:materialize, params, page_opts) do
     content_tag :ul, class: "pagination" do
-      raw_pagination_links(paginator, params)
-      |> Enum.map(&page(&1, url_params, args, page_param, path, paginator, :materialize))
+      raw_pagination_links(page_opts.paginator, params)
+      |> Enum.map(&page(&1, page_opts, :materialize))
     end
   end
 
   # Bulma implementation
-  defp _pagination_links(paginator,
-         view_style: :bulma,
-         path: path,
-         args: args,
-         page_param: page_param,
-         params: params
-       ) do
-    url_params = Keyword.drop(params, Keyword.keys(@raw_defaults))
-
+  defp _pagination_links(:bulma, params, page_opts) do
     content_tag :nav, class: "pagination is-centered" do
       content_tag :ul, class: "pagination-list" do
-        raw_pagination_links(paginator, params)
-        |> Enum.map(&page(&1, url_params, args, page_param, path, paginator, :bulma))
+        raw_pagination_links(page_opts.paginator, params)
+        |> Enum.map(&page(&1, page_opts, :bulma))
       end
     end
   end
 
-  defp page({:ellipsis, true}, url_params, args, page_param, path, paginator, :foundation) do
-    page({:ellipsis, ""}, url_params, args, page_param, path, paginator, :foundation)
+  defp page({:ellipsis, true}, page_opts, :foundation) do
+    page({:ellipsis, ""}, page_opts, :foundation)
   end
 
-  defp page({:ellipsis, true}, url_params, args, page_param, path, paginator, style) do
-    page(
-      {:ellipsis, unquote(@raw_defaults[:ellipsis])},
-      url_params,
-      args,
-      page_param,
-      path,
-      paginator,
-      style
-    )
+  defp page({:ellipsis, true}, page_opts, style) do
+    page({:ellipsis, unquote(@raw_defaults[:ellipsis])}, page_opts, style)
   end
 
-  defp page({:ellipsis, text}, _url_params, _args, _page_param, _path, paginator, :semantic) do
-    content_tag(:div, safe(text),
-      class: link_classes_for_style(paginator, :ellipsis, :semantic) |> Enum.join(" ")
-    )
+  defp page({:ellipsis, text}, page_opts, :semantic) do
+    class = link_classes_for_style(page_opts.paginator, :ellipsis, :semantic) |> Enum.join(" ")
+    content_tag(:div, safe(text), class: class)
   end
 
-  defp page({:ellipsis, text}, _url_params, _args, _page_param, _path, paginator, style) do
+  defp page({:ellipsis, text}, page_opts, style) do
+    paginator = page_opts.paginator
+
     content_tag(:li, class: li_classes_for_style(paginator, :ellipsis, style) |> Enum.join(" ")) do
       style
       |> ellipsis_tag
@@ -325,7 +271,18 @@ defmodule Scrivener.HTML do
     end
   end
 
-  defp page({text, page_number}, url_params, args, page_param, path, paginator, :semantic) do
+  defp page(
+         {text, page_number},
+         %{
+           paginator: paginator,
+           url_params: url_params,
+           path: path,
+           args: args,
+           page_param: page_param,
+           link_fun: link_fun
+         },
+         :semantic
+       ) do
     params_with_page =
       url_params ++
         case page_number > 1 do
@@ -341,7 +298,7 @@ defmodule Scrivener.HTML do
           class: link_classes_for_style(paginator, page_number, :semantic) |> Enum.join(" ")
         )
       else
-        link(safe(text),
+        link_fun.(safe(text),
           to: to,
           rel: Scrivener.HTML.SEO.rel(paginator, page_number),
           class: li_classes_for_style(paginator, page_number, :semantic) |> Enum.join(" ")
@@ -354,7 +311,18 @@ defmodule Scrivener.HTML do
     end
   end
 
-  defp page({text, page_number}, url_params, args, page_param, path, paginator, style) do
+  defp page(
+         {text, page_number},
+         %{
+           paginator: paginator,
+           url_params: url_params,
+           path: path,
+           args: args,
+           page_param: page_param,
+           link_fun: link_fun
+         },
+         style
+       ) do
     params_with_page =
       url_params ++
         case page_number > 1 do
@@ -364,25 +332,22 @@ defmodule Scrivener.HTML do
 
     content_tag :li, class: li_classes_for_style(paginator, page_number, style) |> Enum.join(" ") do
       to = apply(path, args ++ [params_with_page])
+      class = link_classes_for_style(paginator, page_number, style) |> Enum.join(" ")
 
       if to do
         if active_page?(paginator, page_number) do
-          content_tag(:a, safe(text),
-            class: link_classes_for_style(paginator, page_number, style) |> Enum.join(" ")
-          )
+          content_tag(:a, safe(text), class: class)
         else
-          link(safe(text),
+          link_fun.(safe(text),
             to: to,
             rel: Scrivener.HTML.SEO.rel(paginator, page_number),
-            class: link_classes_for_style(paginator, page_number, style) |> Enum.join(" ")
+            class: class
           )
         end
       else
         style
         |> blank_link_tag()
-        |> content_tag(safe(text),
-          class: link_classes_for_style(paginator, page_number, style) |> Enum.join(" ")
-        )
+        |> content_tag(safe(text), class: class)
       end
     end
   end


### PR DESCRIPTION
Adds a new `:link_fun` option to set the link function.   Defaults to `Phoenix.HTML.link/2`.

This will allow to use Scrivener with Phoenix LiveView which has [own link generation function](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#live_link/1) for "live navigation".

I've replaced some common arguments with `page_opts` map and now not sure it was needed :) If you don't like it I'll try to turn it back.

P.S. I've been using Scrivener for years! Such a handy library, thank you!